### PR TITLE
Optimise get_sides() in standard pipeline

### DIFF
--- a/pipline_modules/standard.py
+++ b/pipline_modules/standard.py
@@ -50,6 +50,7 @@ def get_sides(Graph, borders):
     faces = []
     all_visited = set()
     nodes = list(Graph.nodes)
+    borders = set(borders)
     shortest_cycle_length = np.sqrt(len(borders))//5
     with tqdm(total=len(nodes)) as pbar:
         while len(nodes):


### PR DESCRIPTION
In pipeline_modules.standard.get_sides() an unreasonable amount of time is spent doing presence checks over large lists. By converting this to a set first we can improve runtimes by a factor of 100-1000x.

On my machine this takes the runtime for get_sides() from 10 minutes to 2 seconds.